### PR TITLE
Sync portfolio with resume, backend-focused refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Static portfolio site (HTML/CSS/JS only). No package manager, build, test, lint, or CI. Live at https://ashishvats056.github.io/ via GitHub Pages — push to `main` to publish.
+
+## Structure
+
+- `index.html` — entire site: About / Resume / Contact sections (Projects nav + article are commented out, see below)
+- `assets/css/style.css` — all styles (`.skill-progress-*` rules are unused leftovers; skills are grouped text lists via `.skills-category-text`)
+- `assets/js/script.js` — all interactivity (vanilla JS, `"use strict"`)
+- `assets/images/` — `my-photo.gif` is the live avatar; `project-*` / `avatar-*` files are mostly unused leftovers from the `codewithsadee/vcard-personal-portfolio` template (placeholders still commented out in `index.html`)
+
+## Verify
+
+No toolchain. Open `index.html` directly in a browser (or `npx serve .`) and click through nav, filters, modal, and contact form. External CDN deps (Google Fonts Poppins, `ionicons@5.5.2` via unpkg) require network.
+
+## Gotchas
+
+- JS wiring is `data-*` attribute driven — keep hook names in sync between `index.html` and `script.js`:
+  - nav: `data-nav-link` button text must case-insensitively match `data-page` on the `<article>` (nav loop also matches on `innerHTML`, so keep button labels plain text)
+  - project filter: `data-filter-btn` / `data-select-item` text must match `data-category` on `data-filter-item` entries (`filterFunc` lowercases button text before comparing); desktop `filter-list` and mobile `filter-select-box` both drive the same `filterFunc` — update both
+  - `data-selecct-value` (three c's) is a typo in both `index.html` and `script.js` — preserve it, do not "fix" one side
+  - sidebar toggle: `data-sidebar` + `data-sidebar-btn`; testimonial modal: `data-testimonials-*` + `data-modal-container`/`data-overlay`/`data-modal-close-btn`; contact form: `data-form`/`data-form-input`/`data-form-btn`
+- Contact form has no backend: submit builds a `mailto:ashishvats056@gmail.com` link via `window.location.href`. Submit button stays `disabled` until `form.checkValidity()` passes (`script.js:109-119`).
+- Projects section is commented out (nav `<li>` + `<article data-page="projects">`, both tagged `COMMENTED OUT`); `script.js` select/filter blocks have null guards so they no-op while it is gone. To re-enable: uncomment both blocks — do not uncomment only one (orphan nav button does nothing; orphan article is unreachable).
+- Resume `<article>` title is a link to the Drive resume PDF (`resume-title-link` + `open-outline` icon, tooltip "View resume doc"). Keep the anchor wrapping the header; icon must stay inside the `h2` (flex keeps it on one line).
+- Personal data (email, phone, location, resume text, testimonial) is hardcoded in `index.html` — edit content there directly. Positioning is backend-focused for backend-role applications; keep it that way.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -277,6 +277,32 @@ article.active {
     border-radius: 3px;
 }
 
+/* resume title is a link to the full resume — give it a link affordance */
+.resume-title-link {
+    display: inline-block;
+}
+
+.resume-title-link .article-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.resume-link-icon {
+    font-size: var(--fs-5);
+    flex-shrink: 0;
+    color: var(--orange-yellow-crayola);
+}
+
+.resume-title-link:hover .article-title {
+    color: var(--orange-yellow-crayola);
+}
+
+.resume-title-link:hover .article-title::after {
+    width: 100%;
+    transition: width 0.3s ease;
+}
+
 .has-scrollbar::-webkit-scrollbar {
     width: 5px;
     /* for vertical scrollbar */
@@ -902,6 +928,13 @@ main {
 
 .skills-item:not(:last-child) {
     margin-bottom: 15px;
+}
+
+.skills-category-text {
+    color: var(--light-gray);
+    font-size: var(--fs-6);
+    font-weight: var(--fw-300);
+    line-height: 1.6;
 }
 
 .skill .title-wrapper {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -57,16 +57,23 @@ const selectItems = document.querySelectorAll("[data-select-item]");
 const selectValue = document.querySelector("[data-selecct-value]");
 const filterBtn = document.querySelectorAll("[data-filter-btn]");
 
-select.addEventListener("click", function () {
-    elementToggleFunc(this);
-});
+// projects section is currently commented out in index.html, so these may be null — guard all uses
+if (select) {
+    select.addEventListener("click", function () {
+        elementToggleFunc(this);
+    });
+}
 
 // add event in all select items
 for (let i = 0; i < selectItems.length; i++) {
     selectItems[i].addEventListener("click", function () {
         let selectedValue = this.innerText.toLowerCase();
-        selectValue.innerText = this.innerText;
-        elementToggleFunc(select);
+        if (selectValue) {
+            selectValue.innerText = this.innerText;
+        }
+        if (select) {
+            elementToggleFunc(select);
+        }
         filterFunc(selectedValue);
     });
 }
@@ -92,10 +99,14 @@ let lastClickedBtn = filterBtn[0];
 for (let i = 0; i < filterBtn.length; i++) {
     filterBtn[i].addEventListener("click", function () {
         let selectedValue = this.innerText.toLowerCase();
-        selectValue.innerText = this.innerText;
+        if (selectValue) {
+            selectValue.innerText = this.innerText;
+        }
         filterFunc(selectedValue);
 
-        lastClickedBtn.classList.remove("active");
+        if (lastClickedBtn) {
+            lastClickedBtn.classList.remove("active");
+        }
         this.classList.add("active");
         lastClickedBtn = this;
     });

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                 <div class="info-content">
                     <h1 class="name" title="Ashish Vats">Ashish Vats</h1>
 
-                    <p class="title">SDE</p>
+                    <p class="title">Software Development Engineer</p>
                 </div>
 
                 <button class="info_more-btn" data-sidebar-btn>
@@ -102,7 +102,7 @@
                         <div class="contact-info">
                             <p class="contact-title">Location</p>
 
-                            <address>Bengaluru, Karanataka, India</address>
+                            <address>Bengaluru, Karnataka, India</address>
                         </div>
                     </li>
                 </ul>
@@ -111,7 +111,7 @@
 
                 <ul class="social-list">
                     <li class="social-item">
-                        <a href="https://github.com/ashish-stratgeek" class="social-link">
+                        <a href="https://github.com/ashishvats056" class="social-link">
                             <ion-icon name="logo-github"></ion-icon>
                         </a>
                     </li>
@@ -123,7 +123,7 @@
                     </li>
 
                     <li class="social-item">
-                        <a href="https://github.com/ashishvats056" class="social-link">
+                        <a href="https://github.com/ashish-vats-razor" class="social-link">
                             <ion-icon name="logo-github"></ion-icon>
                         </a>
                     </li>
@@ -150,9 +150,11 @@
                         <button class="navbar-link" data-nav-link>Resume</button>
                     </li>
 
+                    <!-- Projects nav commented out — re-enable with the projects article when open-source projects are added
                     <li class="navbar-item">
                         <button class="navbar-link" data-nav-link>Projects</button>
                     </li>
+                    -->
 
                     <li class="navbar-item">
                         <button class="navbar-link" data-nav-link>Contact</button>
@@ -171,22 +173,21 @@
 
                 <section class="about-text">
                     <p>
-                        I'm a dedicated Software Development Engineer specializing in full-stack development with
-                        expertise in Python, ReactJS, and SQL. Currently driving innovation at StratGeek, I've led the
-                        end-to-end development of scalable software solutions, integrating with vital developer tools
-                        and optimizing performance through advanced data strategies.
+                        I'm a Software Development Engineer at Razorpay building backend and infrastructure
+                        systems at scale.
+                        I work across fintech, distributed systems, API gateways, reliability and developer
+                        automation.
                     </p>
 
                     <p>
-                        With a foundation in Mathematics from the University of Delhi and hands-on training from Besant
-                        Technologies, I bring a blend of technical proficiency and creative problem-solving skills to
-                        every project. I thrive in collaborative environments and am passionate about leveraging
-                        technology to deliver impactful solutions.
+                        I enjoy building scalable systems, solving reliability problems, and automating things
+                        that shouldn't need humans.
+                        Previously, I was the sole engineer at a seed-stage startup, taking a product from 0→1.
                     </p>
 
                     <p>
-                        Let's connect to explore how we can create meaningful impact together in the realm of software
-                        development.
+                        Let's connect - happy to talk about engineering, systems, ideas or interesting problems.
+                        I'm always open to opportunities to build great systems together with great people.
                     </p>
                 </section>
 
@@ -200,8 +201,7 @@
                     <ul class="service-list">
                         <li class="service-item">
                             <div class="service-icon-box">
-                                <img src="./assets/images/icon-code.svg
-        " alt="Backend development icon" width="40" />
+                                <img src="./assets/images/icon-code.svg" alt="Backend development icon" width="40" />
                             </div>
 
                             <div class="service-content-box">
@@ -210,42 +210,9 @@
                                 </h4>
 
                                 <p class="service-item-text">
-                                    Creation of complete and robust backend
-                                    with speciality in Python.
-                                </p>
-                            </div>
-                        </li>
-
-                        <li class="service-item">
-                            <div class="service-icon-box">
-                                <img src="./assets/images/icon-webdev.svg" alt="Web development icon" width="40" />
-                            </div>
-
-                            <div class="service-content-box">
-                                <h4 class="h4 service-item-title">
-                                    Web development
-                                </h4>
-
-                                <p class="service-item-text">
-                                    High-quality development of sites at the
-                                    professional level.
-                                </p>
-                            </div>
-                        </li>
-
-                        <li class="service-item">
-                            <div class="service-icon-box">
-                                <img src="./assets/images/icon-database.svg" alt="Database icon" width="40" />
-                            </div>
-
-                            <div class="service-content-box">
-                                <h4 class="h4 service-item-title">
-                                    Database Management
-                                </h4>
-
-                                <p class="service-item-text">
-                                    Professional development of applications
-                                    for iOS and Android.
+                                    Design and development of robust backend
+                                    services and microservices, primarily in
+                                    Go and Python.
                                 </p>
                             </div>
                         </li>
@@ -257,12 +224,48 @@
 
                             <div class="service-content-box">
                                 <h4 class="h4 service-item-title">
-                                    API Integration
+                                    Distributed systems & APIs
                                 </h4>
 
                                 <p class="service-item-text">
-                                    Seamless integration with third party
-                                    APIs to boost functionality.
+                                    REST and gRPC services, API gateway systems,
+                                    and middleware built for production traffic.
+                                </p>
+                            </div>
+                        </li>
+
+                        <li class="service-item">
+                            <div class="service-icon-box">
+                                <img src="./assets/images/icon-database.svg" alt="Database icon" width="40" />
+                            </div>
+
+                            <div class="service-content-box">
+                                <h4 class="h4 service-item-title">
+                                    Data pipelines & caching
+                                </h4>
+
+                                <p class="service-item-text">
+                                    High-throughput ingestion pipelines and
+                                    caching layers that keep analytics queries
+                                    fast at scale.
+                                </p>
+                            </div>
+                        </li>
+
+                        <li class="service-item">
+                            <div class="service-icon-box">
+                                <img src="./assets/images/icon-webdev.svg" alt="Infrastructure icon" width="40" />
+                            </div>
+
+                            <div class="service-content-box">
+                                <h4 class="h4 service-item-title">
+                                    Infrastructure & reliability
+                                </h4>
+
+                                <p class="service-item-text">
+                                    CI/CD automation, Terraform, and service
+                                    reliability practices that keep systems
+                                    available and secure.
                                 </p>
                             </div>
                         </li>
@@ -280,7 +283,7 @@
                         <li class="testimonials-item">
                             <div class="content-card" data-testimonials-item>
                                 <figure class="testimonials-avatar-box">
-                                    <img src="https://media.licdn.com/dms/image/D5603AQE1sBTKNdRqLw/profile-displayphoto-shrink_800_800/0/1721982775011?e=1727913600&v=beta&t=GeqnJRsARME7VEcKGH4HAEZ00cRZQSDhnPEFnXJcKr4"
+                                    <img src="https://media.licdn.com/dms/image/v2/D4D03AQExoeQOxqXJNw/profile-displayphoto-scale_100_100/B4DZ7VON6aIIAY-/0/1781693737225?e=1790208000&v=beta&t=2rvZDSpS_7vTXqyANm-mDDebvx_jmr603bzFGASvGTE"
                                         alt="Naseem Shaik" width="60" data-testimonials-avatar />
                                 </figure>
 
@@ -480,10 +483,12 @@
             -->
 
             <article class="resume" data-page="resume">
-                <a href="https://www.linkedin.com/in/ashishvats056/overlay/1721658949525/single-media-viewer/?profileId=ACoAAEKJmgoBbVqSLAR7Sqxn73agL0DxaLDDmkw"
-                    target="_blank">
+                <a class="resume-title-link"
+                    href="https://drive.google.com/file/d/1vrzUN8hgYJq2Vqm711jNzW-A8sRHH4in/view?usp=sharing"
+                    target="_blank" rel="noopener" title="View resume doc">
                     <header>
-                        <h2 class="h2 article-title">Resume</h2>
+                        <h2 class="h2 article-title">Resume <ion-icon name="open-outline" title="View resume doc"
+                                class="resume-link-icon"></ion-icon></h2>
                     </header>
                 </a>
 
@@ -499,42 +504,79 @@
                     <ol class="timeline-list">
                         <li class="timeline-item">
                             <h4 class="h4 timeline-item-title">
-                                Software Development Engineer
+                                Software Development Engineer — Razorpay
                             </h4>
 
-                            <span>Aug 2023 — Present</span>
+                            <span>Sep 2024 — Present | Bengaluru, India | Go, PHP</span>
 
                             <p class="timeline-text">
-                                • Developed the entire product’s Frontend, Backend, and Database from the ground up,
-                                writing 150k+ lines of code, currently used by 30+ users.
-                            <p class="timeline-text">• Integrated with developer tools like GitHub, Jira, Slack, and
-                                BitBucket to provide analytics through configurable dashboards with 50+ graph options.
+                                • Built an AI-driven alert analysis workflow that analyzes production
+                                incident alerts and suggests root causes and fixes, accelerating
+                                resolution for ~80% of critical alerts.
                             </p>
-                            <p class="timeline-text">• Ensured streamlined onboarding with Google SSO Signup, OAuth
-                                integration of user-chosen developertools, and team invites with controlled
-                                authorization.</p>
                             <p class="timeline-text">
-                                • Built a scheduler to allow the creation of recurrent reports, alerts, and leaderboards
-                                that can be streamed over Slack/email using a cron job in the backend.</p>
+                                • Designed and implemented a high-throughput merchant risk screening
+                                pipeline, ingesting 30M+ revoked mobile-number records from CDOT India
+                                initially and ~100K daily thereafter, identifying 1,000+ fraudulent
+                                accounts.
+                            </p>
                             <p class="timeline-text">
-                                • Designed and implemented a caching mechanism with a daily cron updater that fetches
-                                millions of rows of data daily.</p>
+                                • Led migration from an open-source Lua-based API gateway to an in-house
+                                Go-based gateway, developing custom plugins/middleware and
+                                request-mirroring infrastructure to validate V2 behavior against
+                                production V1 traffic before migration.
+                            </p>
                             <p class="timeline-text">
-                                • Built a data pipeline that provides insights for any larger date range in under 5
-                                seconds by using a combination of cached data and minimal real-time API calls.</p>
+                                • Automated authorization-policy onboarding across teams and services
+                                through CI validation and approval workflows, removing team dependencies
+                                and reducing on-call effort.
+                            </p>
                             <p class="timeline-text">
-                                • Built an error-handling wrapper at the application level that can categorize, decide
-                                actions, and notify through Slack.</p>
+                                • Improved service reliability by resolving Consul failures through
+                                jittered retries and optimized combined data creation, achieving 99.99%
+                                availability during failure recovery.
+                            </p>
                             <p class="timeline-text">
-                                • Created and maintained 20+ database tables with periodic optimizations and encryption.
-                                Supported migrations, ensuring backward compatibility without any downtime.</p>
+                                • Built DepGuard, a centrally managed security automation agent that scans
+                                1K+ repositories for vulnerable external dependencies and raises
+                                remediation PRs through scheduled GitHub CI workflows.
+                            </p>
                             <p class="timeline-text">
-                                • Built features to support access based on plan type and user access level, including a
-                                page to experience the product without signing up, improving conversion rates.</p>
+                                • Automated Funds on Hold (FOH) workflows on the internal SOP platform,
+                                streamlining transaction risk investigations and reducing manual
+                                operational effort by 50%.
+                            </p>
+                        </li>
+
+                        <li class="timeline-item">
+                            <h4 class="h4 timeline-item-title">
+                                Software Development Engineer — StratGeek
+                            </h4>
+
+                            <span>Aug 2023 — Sep 2024 | Bengaluru, India | Python, React</span>
+
                             <p class="timeline-text">
-                                • As the team and features scaled, took on numerous experimental projects, brainstormed
-                                with stakeholders, ensured coding standards, and contributed to technical design
-                                documents.
+                                • Sole engineer responsible for designing and building the entire product
+                                stack (React frontend, Python backend, and database) for a project
+                                analytics platform used by 30+ active users, from concept to production.
+                            </p>
+                            <p class="timeline-text">
+                                • Integrated developer tools including GitHub, Jira, Slack, and Bitbucket
+                                to build configurable analytics dashboards with 50+ visualization options.
+                            </p>
+                            <p class="timeline-text">
+                                • Designed a data pipeline and caching system processing millions of
+                                records daily, delivering analytics queries across large date ranges in
+                                under 5 seconds.
+                            </p>
+                            <p class="timeline-text">
+                                • Built a scheduler system for automated reports and alerts, delivering
+                                insights via Slack and email using backend cron workflows.
+                            </p>
+                            <p class="timeline-text">
+                                • Designed and maintained 20+ relational database tables with schema
+                                migrations, encryption, and backward-compatible deployments for zero
+                                downtime releases.
                             </p>
                         </li>
 
@@ -573,14 +615,26 @@
                     <ol class="timeline-list">
                         <li class="timeline-item">
                             <h4 class="h4 timeline-item-title">
+                                Go - The Complete Guide
+                            </h4>
+
+                            <span>2024 | Udemy</span>
+
+                            <p class="timeline-text">
+                                Go
+                            </p>
+                        </li>
+
+                        <li class="timeline-item">
+                            <h4 class="h4 timeline-item-title">
                                 Full Stack Masters Program
                             </h4>
 
-                            <!-- <p class="timeline-text">
-                                    Nemo enim ipsam voluptatem blanditiis
-                                    praesentium voluptum delenit atque corrupti,
-                                    quos dolores et qvuas molestias exceptur.
-                                </p> -->
+                            <span>2024</span>
+
+                            <p class="timeline-text">
+                                Java, React, SQL Server
+                            </p>
                         </li>
 
                         <li class="timeline-item">
@@ -589,11 +643,11 @@
                                 Bootcamp
                             </h4>
 
-                            <!-- <p class="timeline-text">
-                                    Nemo enims ipsam voluptatem, blanditiis
-                                    praesentium voluptum delenit atque corrupti,
-                                    quos dolores et quas molestias exceptur.
-                                </p> -->
+                            <span>2023 | Udemy</span>
+
+                            <p class="timeline-text">
+                                Python
+                            </p>
                         </li>
                     </ol>
                 </section>
@@ -638,44 +692,41 @@
                     <ul class="skills-list content-card">
                         <li class="skills-item">
                             <div class="title-wrapper">
-                                <h5 class="h5">Backend Development</h5>
-                                <data value="90">90%</data>
+                                <h5 class="h5">Languages</h5>
                             </div>
 
-                            <div class="skill-progress-bg">
-                                <div class="skill-progress-fill" style="width: 90%"></div>
-                            </div>
+                            <p class="skills-category-text">Go • Python • Java</p>
                         </li>
 
                         <li class="skills-item">
                             <div class="title-wrapper">
-                                <h5 class="h5">Web Development</h5>
-                                <data value="70">70%</data>
+                                <h5 class="h5">Backend</h5>
                             </div>
 
-                            <div class="skill-progress-bg">
-                                <div class="skill-progress-fill" style="width: 70%"></div>
-                            </div>
+                            <p class="skills-category-text">Distributed Systems • Microservices • REST • gRPC • Data
+                                Pipelines</p>
                         </li>
 
                         <li class="skills-item">
                             <div class="title-wrapper">
-                                <h5 class="h5">Database Management</h5>
-                                <data value="80">80%</data>
+                                <h5 class="h5">Infrastructure</h5>
                             </div>
 
-                            <div class="skill-progress-bg">
-                                <div class="skill-progress-fill" style="width: 80%"></div>
+                            <p class="skills-category-text">CI/CD • Terraform • GitHub • Consul • Gateway Systems</p>
+                        </li>
+
+                        <li class="skills-item">
+                            <div class="title-wrapper">
+                                <h5 class="h5">Databases</h5>
                             </div>
+
+                            <p class="skills-category-text">PostgreSQL • MySQL • MongoDB • Trino • Hive</p>
                         </li>
                     </ul>
                 </section>
             </article>
 
-            <!--
-                - #PROJECTS
-            -->
-
+            <!-- PROJECTS SECTION COMMENTED OUT — re-enable when open-source projects are added
             <article class="projects" data-page="projects">
                 <header>
                     <h2 class="h2 article-title">Projects</h2>
@@ -942,6 +993,7 @@
                     </ul>
                 </section>
             </article>
+            END PROJECTS SECTION COMMENTED OUT -->
 
             <!--
                 - #CONTACT


### PR DESCRIPTION
Syncs the outdated portfolio with the current resume and repositions for backend roles:

- Experience: new Razorpay SDE item (Sep 2024 - Present), StratGeek rewritten (Aug 2023 - Sep 2024); Trainee untouched
- About + services rewritten backend-focused (Go, distributed systems, gateways, pipelines, reliability)
- Skills: grouped text lists replacing percentage bars; certs keep Full Stack Masters, add Go guide + org/years
- Projects section commented out (nav + article); script.js select/filter null-guarded
- Resume title is a visible link to the Drive PDF (icon + 'View resume doc' tooltip)
- Sidebar: SDE title, Karnataka fix, ashish-vats-razor social
- Adds AGENTS.md contributor notes

Verified locally over HTTP: 200s, no live Projects remnants, clean JS syntax.